### PR TITLE
chore:fix: restrict node engine versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+#jetbrains IDE
+.idea

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "private": true,
   "devDependencies": {
     "ts-node": "^10.4.0"
+  },
+  "engines": {
+    "node": ">=16 <17"
   }
 }


### PR DESCRIPTION
I ran into the following error when running `yarn demo` with node versions higher than `17.0.0`:
```
Error HH604: Error running JSON-RPC server: error:0308010C:digital envelope routines::unsupported
```

It looks like it is due to Node 17.0.0 starting to use OpenSSL3
https://github.com/webpack/webpack/issues/14532#issuecomment-947807590

It can be solved for instance by:
- restricting the node engine versions in top level `package.json`
- or using the `--openssl-legacy-provider` `NODE_OPTIONS` flag as suggested [here](https://stackoverflow.com/a/69748147)

I suggest the first solution because
- I think unless one is familiar with the flag `--openssl-legacy-provider`, it will raise questions when one sees it used in a script
- we would need to add this flag to all the scripts that need it  
- using `engines` in `package.json` is probably a more common way to avoid such compatibility issues.

### Test plan
- on `main` branch:
  - `yarn demo` using NodeJS version >= 17.0.0: you'll see the error message mentioned above
  - `yarn demo` using NodeJS >= 16.0.0 < 17.0.0: script will execute without issues
- on this branch:
  You'll be warned that you must use a node version between 16.0.0 and 17.0.0 to run the script
  ```
  The engine "node" is incompatible with this module. Expected version ">=16 <17". Got "18.9.0"
  ```
(I didn't test with versions lower than 16.0.0)

